### PR TITLE
Parametrize which winget version to get

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
     - main
+    - develop
   pull_request:
     branches:
     - main
+    - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,7 +28,7 @@ jobs:
     steps:
     - name: Install winget
       id: install-winget
-      uses: Cyberboss/install-winget@v1
+      uses: blessio/install-winget@develop
 
     - name: Check Version
       shell: bash
@@ -46,12 +48,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'windows-2022', 'windows-latest' ]
-        repeat: [ 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' ]
+        repeat: [ 'a', 'b', 'c', 'd', 'e', 'f', 'g' ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install winget
       id: install-winget
-      uses: Cyberboss/install-winget@v1
+      uses: blessio/install-winget@develop
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ The GitHub token to use when interacting with the GitHub API. Used to bypass una
 
 **Recommendation is to set this to ${{ secrets.GITHUB_TOKEN }} or some other available token** as GitHub runners tend to often come with exhausted rate limits.
 
+#### `wget_release_id` (Optional)
+
+This is used to be able to pin (make immutable) the version of winget that is taken github. To see which versions (you need the release-id) is possible to use plese check the github API for the release of [winget-cli](https://github.com/microsoft/winget-cli) this can be checked by looking for the topmost `id:` attribute here: https://api.github.com/repos/microsoft/winget-cli/releases . 
+
 ### Outputs
 
 #### `winget-version`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # install-winget
 
-Action to install [winget-cli](https://github.com/microsoft/winget-cli) v1.8.1911 on Windows runners
+Action to install [winget-cli](https://github.com/microsoft/winget-cli) default v1.8.1911 on Windows runners. Other versions can be installed by changing `wget_release_id` parameter.
 
 Currently only supports `windows-2022`/`window-latest` runner image.
 
@@ -24,6 +24,7 @@ jobs:
       uses: Cyberboss/install-winget@v1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        wget_release_id: latest
 
     - name: Install wingetcreate
       run: winget install wingetcreate --disable-interactivity --accept-source-agreements

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Install winget
-description: Installs the latest version of winget
+description: Installs a version of winget
 author: Dominion/Cyberboss
 branding:
   icon: arrow-down-circle
@@ -9,6 +9,11 @@ inputs:
     description: 'No scopes GitHub token for querying the API and downloading from winget-cli releases'
     required: false
     default: 'NONE'
+  wget_release_id:
+    description: 'Specify desired release-id of winget can be specified here. By default, a recent stable release will be selected by the action author. To see what versions are available, look into https://api.github.com/repos/microsoft/winget-cli/releases'
+    required: false
+    default: '164835566' # latest can be used here
+
 outputs:
   winget-version:
     description: "The version of winget installed"
@@ -48,8 +53,7 @@ runs:
           Write-Host "No token present"
         }
 
-        $releaseURL = "https://api.github.com/repos/microsoft/winget-cli/releases/latest"
-        $releaseURL = "https://api.github.com/repos/microsoft/winget-cli/releases/164835566"
+        $releaseURL = "https://api.github.com/repos/microsoft/winget-cli/releases/${{ inputs.wget_release_id }}"
         $gitHubReleasesResponse = Invoke-RestMethod $releaseURL -Headers $headers
         $wingetReleaseAssets = $gitHubReleasesResponse.assets
         $latestWingetMsixBundleUri = $wingetReleaseAssets.browser_download_url | Where-Object {$_.EndsWith(".msixbundle")}


### PR DESCRIPTION
Thank you for fixing the main tree to use a stable version of winget.

Still, hardcoding the used version in the base action is also limiting the improvements from winget team. I believe that having a parameter is one of the best ways, because it can achieve both goals of being flexible and stable. At the same time, it keeps the power of the action user (client) to fix the used winget release version (which is anyway recommended).

This PR does exactly that and was tested in the source branch - it is backward compatible to the current version.

The changes in file: `.github/workflows/test_action.yml` should be ignored (they were needed to test after all).

Please merge this backward compatible change :)

