### PR TITLE
Make failure message more clear help issue #8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,15 @@ runs:
     - name: Install winget
       shell: powershell
       run: |
+        echo "PROVISIONING WINGET"
         Add-AppxProvisionedPackage -Online -PackagePath ./winget.msixbundle -LicensePath ./winget_License1.xml
+
+    - name: Installing Winget
+      shell: powershell
+      run: |
+        echo "INSTALLING WINGET"
+        $ProgressPreference = 'SilentlyContinue'
+        Add-AppxPackage .\winget.msixbundle
 
     - name: Cleanup Downloads
       shell: powershell


### PR DESCRIPTION
Related to issue #8.

When this code is added the error message shows the root-cause why #8 happens.
It does not resolve the issue, rather proves that the error is to be fixed in the bundler of winget or VCLibs or Desktop installer. 

Although the issue is not fixed, this PR makes the code easier to maintain so I suggest merging it.


